### PR TITLE
Bump Elixir to 1.19.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.3-otp-27
-erlang 27.3.3
+elixir 1.19.5-otp-28
+erlang 28.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.15.4-erlang-26.0.2-debian-bullseye-20230612-slim
 #
-ARG ELIXIR_VERSION=1.18.3
-ARG OTP_VERSION=27.3.3
-ARG DEBIAN_VERSION=bookworm-20250428-slim
+ARG ELIXIR_VERSION=1.19.5
+ARG OTP_VERSION=28.5.0.1
+ARG DEBIAN_VERSION=trixie-20260518-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Red.MixProject do
     [
       app: :red,
       version: "0.1.0",
-      elixir: "~> 1.14",
+      elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Bumps the app to the shared Elixir v1 tuple:

- Elixir 1.19.5
- Erlang/OTP 28.5
- Docker OTP 28.5.0.1
- Debian trixie-20260518-slim